### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All objects were set will not be removed next manage.
 Mem.set removes objects from next cleanup list.
 
 
-####Arguments
+#### Arguments
 
 Unique name
 
@@ -197,6 +197,6 @@ var Mem = require('mem');
 bower install mem.js
 ```
 
-##Dependencies
+## Dependencies
 
 - [Underscore.js](http://underscorejs.org/) or [Lo-Dash](http://lodash.com/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
